### PR TITLE
Make load balancer depend on internet gateway

### DIFF
--- a/aws-cf/edgedb-aurora.yml
+++ b/aws-cf/edgedb-aurora.yml
@@ -584,6 +584,7 @@ Resources:
   # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-loadbalancer.html
   LoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    DependsOn: VPCGatewayAttachment
     Properties:
       Type: network
       Name: !Sub "edgedb-${InstanceName}-load-balancer"


### PR DESCRIPTION
It appears that the load balancer could be created before the internet gateway is attached to the VPC. This change makes the dependency explicit by adding a `DependsOn` to the load balancer.