### PR TITLE
Pin edgedb image version to 2

### DIFF
--- a/gcp/deployment.yaml
+++ b/gcp/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: edgedb
-          image: edgedb/edgedb
+          image: edgedb/edgedb:2
           ports:
             - containerPort: 5656
           readinessProbe:


### PR DESCRIPTION
[Without an explicit version or imagePullPolicy](https://kubernetes.io/docs/concepts/containers/images/#updating-images), k8s will set
imagePullPolicy to Always and automatically upgrades the server image to
a new version without dump/restore in a future k8s re-deployment,
breaking the server if the new version is a major bump.

Setting imagePullPolicy to IfNotPresent is not always safe from the same
issue, because k8s may want to re-deploy the pod onto a new node without
an image of the same major version.