### PR TITLE
Update digitalocean image builder

### DIFF
--- a/digitalocean-1-click/README.md
+++ b/digitalocean-1-click/README.md
@@ -7,7 +7,7 @@
 
 ```bash
 export DIGITALOCEAN_ACCESS_TOKEN=<your-token-here>
-packer build -var 'package_version=1' image.pkr.hcl
+packer build -var 'package_version=2' image.pkr.hcl
 ```
 
 Documentation on building images for DigitalOcean Marketplace is

--- a/digitalocean-1-click/cleanup.sh
+++ b/digitalocean-1-click/cleanup.sh
@@ -5,6 +5,7 @@ history -c
 cat /dev/null > /root/.bash_history
 unset HISTFILE
 
+apt-get -y purge droplet-agent
 apt-get -y autoremove
 apt-get -y autoclean
 


### PR DESCRIPTION
Digital Ocean seems to have added a constraint that images should not have their `droplet-agent` installed.