### PR TITLE
Updates for EdgeDB 3.0

### DIFF
--- a/digitalocean-1-click/README.md
+++ b/digitalocean-1-click/README.md
@@ -6,8 +6,9 @@
 2. build an image:
 
 ```bash
+packer init .
 export DIGITALOCEAN_ACCESS_TOKEN=<your-token-here>
-packer build -var 'package_version=2' image.pkr.hcl
+packer build -var 'package_version=3' image.pkr.hcl
 ```
 
 Documentation on building images for DigitalOcean Marketplace is

--- a/digitalocean-1-click/cleanup.sh
+++ b/digitalocean-1-click/cleanup.sh
@@ -1,20 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-rm -rf /tmp/* /var/tmp/*
-history -c
-cat /dev/null > /root/.bash_history
-unset HISTFILE
-
-apt-get -y purge droplet-agent
-apt-get -y autoremove
-apt-get -y autoclean
-
-find /var/log -mtime -1 -type f -exec truncate -s 0 {} \;
-rm -rf /var/lib/cloud/instances/*
-rm -rf /var/lib/cloud/instance
-
-rm -f /root/.ssh/authorized_keys /etc/ssh/*key*
-
-dd if=/dev/zero of=/zerofile; sync; rm /zerofile; sync
-cat /dev/null > /var/log/lastlog; cat /dev/null > /var/log/wtmp; cat /dev/null > /var/log/auth.log
-rm -rf /var/log/*.gz /var/log/*.[0-9] /var/log/*-???????? /var/log/*.log
+curl https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/90-cleanup.sh | bash
+rm -rf /opt/digitalocean

--- a/digitalocean-1-click/config.pkr.hcl
+++ b/digitalocean-1-click/config.pkr.hcl
@@ -1,0 +1,8 @@
+packer {
+  required_plugins {
+    digitalocean = {
+      version = ">= 1.0.4"
+      source  = "github.com/digitalocean/digitalocean"
+    }
+  }
+}

--- a/gcp/deployment.yaml
+++ b/gcp/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: edgedb
-          image: edgedb/edgedb:2
+          image: edgedb/edgedb
           ports:
             - containerPort: 5656
           readinessProbe:


### PR DESCRIPTION
- Remove the docker tag `2` from the `edgedb/edgedb` image for the Google Cloud Platform deployment.

- Make the digitalocean image script work again.