### PR TITLE
Bump cloudformation template postgres version to 16.2

### DIFF
--- a/aws-cf/edgedb-aurora.yml
+++ b/aws-cf/edgedb-aurora.yml
@@ -384,7 +384,7 @@ Resources:
     Type: "AWS::RDS::DBCluster"
     Properties:
       Engine: "aurora-postgresql"
-      EngineVersion: "13.4"
+      EngineVersion: "16.2"
       DBClusterIdentifier: !Sub "edgedb-${InstanceName}-postgres-cluster"
       DBSubnetGroupName: !Ref "RDSSubnetGroup"
       MasterUsername: "postgres"


### PR DESCRIPTION
The cloudformation template was broken because the postgres version was no longer available.

This change updates the postgres version to 16.2.

I tested this change by deploying the new template and running `select 1` against the deployed server.